### PR TITLE
feat(*) allow bash errs after sourcing setup_env

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -95,3 +95,5 @@ fi
 nginx -V
 resty -V
 luarocks --version
+
+set +e


### PR DESCRIPTION
the intended usage is sourcing setup_env but we don't want to carry "set -e" over to the later processes.
