### PR TITLE
Include credentials for private github repo

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -29,7 +29,7 @@ if [ ! "$(ls -A $LUAROCKS_DOWNLOAD)" ]; then
 fi
 
 if [ ! "$(ls -A $KONG_NGINX_MODULE_DOWNLOAD)" ]; then
-  git clone -q https://github.com/Kong/lua-kong-nginx-module.git $KONG_NGINX_MODULE_DOWNLOAD
+  git clone -q https://$GITHUB_TOKEN:@github.com/Kong/lua-kong-nginx-module.git $KONG_NGINX_MODULE_DOWNLOAD
 fi
 
 #--------


### PR DESCRIPTION
seems like this commit: https://github.com/Kong/kong-ci/commit/402f40760ee3e73702dc98ef8d39f75e12081d8a#diff-c8c50913d64f0dac4427400f6776fe31R32 by @eskerda does not provide the Github credentials to clone a private repo.