### PR TITLE
feat(setup_env) make Cassandra Setting optional

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -61,9 +61,15 @@ eval `luarocks path`
 # -------------------------------------
 # Setup Cassandra cluster
 # -------------------------------------
-echo "Setting up Cassandra"
-docker run -d --name=cassandra --rm -p 7199:7199 -p 7000:7000 -p 9160:9160 -p 9042:9042 cassandra:$CASSANDRA
-grep -q 'Created default superuser role' <(docker logs -f cassandra)
+if [ -n "$CASSANDRA" ]
+then
+  echo "Setting up Cassandra"
+  docker run -d --name=cassandra --rm -p 7199:7199 -p 7000:7000 -p 9160:9160 -p 9042:9042 cassandra:$CASSANDRA
+  grep -q 'Created default superuser role' <(docker logs -f cassandra)
+else
+  echo "CASSANDRA environment variable not set: skipping setting up Cassandra"
+fi
+
 
 docker run -d --name grpcbin -p 15002:9000 -p 15003:9001 moul/grpcbin
 


### PR DESCRIPTION
This PR allows skipping the Cassandra setting phase when the `$CASSANDRA` variable isn't set.

In some cases it might make sense to skip spinning a Cassandra instance: A plugin might be PostgreSQL-exclusive, or it could have a build for unit tests (which should run without a database).

In my case I want this for efficiency: I want to separate the job into a PG build, and several Cassandra ones. I don't want cassandra specs running on the pg build, nor viceversa. So it does not make sense to set up the Cassandra env on the pg build.

